### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A model context protocol (MCP) server for value change dump (VCD) waveforms.
 
 https://github.com/user-attachments/assets/9d1a6a64-de22-4b5a-a597-685c663c9c79
 
+<a href="https://glama.ai/mcp/servers/kdvs90ijbl"><img width="380" height="200" src="https://glama.ai/mcp/servers/kdvs90ijbl/badge" alt="mcp-vcd MCP server" /></a>
+
 # Tools
 
 - `get-signal`: Provide all changes of the specified signal name to the model's context. This is useful for large waveform files with many signals where you cannot fit the entire VCD file into the model's context window.


### PR DESCRIPTION
This PR adds a badge for the mcp-vcd server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/kdvs90ijbl"><img width="380" height="200" src="https://glama.ai/mcp/servers/kdvs90ijbl/badge" alt="mcp-vcd MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.